### PR TITLE
[update]READMEとソースへの修正を反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ yarn add date-fns
  //開始時刻が変更された場合
   const startTimeChangeHandler = (event:ChangeEvent<HTMLInputElement>) => {
     setStartTime(event.target.value)
-    setOperationTime1(diffTime(event.target.value, endTime, 9))
+    setOperationTime1(diffTime(event.target.value, endTime))
     setOperationTime2("00:00")
   }
 
@@ -155,9 +155,15 @@ yarn add date-fns
 
 ```src\database\daily_itemized_reports\daily_itemized_reports.resolver.ts
 ...
-  @Mutation(() => daily_itemized_reports, { name: 'UpsertDailyItemizedReports' })
-  async upsertDailyItemizedReports(@Args() args: UpsertOnedailyItemizedReportsArgs) {
-    return this.service.upsert({ ...args });
+  @Mutation(() => daily_itemized_reports, {
+    name: 'UpsertDailyItemizedReports',
+  })
+  async upsertDailyItemizedReports(
+    @Args() args: UpsertOnedailyItemizedReportsArgs,
+  ) {
+    return this.service.upsert({
+      ...args,
+    } as Prisma.daily_itemized_reportsUpsertArgs);
   }
 ...
 ```

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,9 +14,6 @@ import { PrismaModule } from './prisma/prisma.module';
       driver: ApolloDriver,
       playground:true,
       autoSchemaFile: join(process.cwd(), 'schema.graphql'),
-      cors: { 
-        origin: "*"
-      },
     }),
     PrismaModule, 
     DatabaseModule],

--- a/backend/src/database/daily_itemized_reports/daily_itemized_reports.resolver.ts
+++ b/backend/src/database/daily_itemized_reports/daily_itemized_reports.resolver.ts
@@ -1,52 +1,91 @@
 import {
-    CreateOnedailyItemizedReportsArgs,
-    DeleteOnedailyItemizedReportsArgs,
-    FindFirstdailyItemizedReportsArgs,
-    FindManydailyItemizedReportsArgs,
-    FindUniquedailyItemizedReportsArgs,
-    daily_itemized_reports,
-    UpdateOnedailyItemizedReportsArgs,
-    UpsertOnedailyItemizedReportsArgs,
+  CreateOnedailyItemizedReportsArgs,
+  DeleteOnedailyItemizedReportsArgs,
+  FindFirstdailyItemizedReportsArgs,
+  FindManydailyItemizedReportsArgs,
+  FindUniquedailyItemizedReportsArgs,
+  daily_itemized_reports,
+  UpdateOnedailyItemizedReportsArgs,
+  UpsertOnedailyItemizedReportsArgs,
 } from '../../@generated/prisma-nestjs-graphql/index';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { DailyItemizedReportsService } from './daily_itemized_reports.service';
+import { Prisma } from '@prisma/client';
 
 @Resolver()
 export class DailyItemizedReportsResolver {
   constructor(private readonly service: DailyItemizedReportsService) {}
 
-  @Query(() => daily_itemized_reports, { name: 'DailyItemizedReports', nullable: true })
+  @Query(() => daily_itemized_reports, {
+    name: 'DailyItemizedReports',
+    nullable: true,
+  })
   async DailyItemizedReports(@Args() args: FindUniquedailyItemizedReportsArgs) {
-    return this.service.findUnique({ ...args });
+    return this.service.findUnique({
+      ...args,
+    } as Prisma.daily_itemized_reportsFindUniqueArgs);
   }
 
-  @Query(() => daily_itemized_reports, { name: 'DailyItemizedReportsFirst', nullable: true })
-  async dailyItemizedReportsFirst(@Args() args: FindFirstdailyItemizedReportsArgs) {
-    return this.service.findFirst({ ...args });
+  @Query(() => daily_itemized_reports, {
+    name: 'DailyItemizedReportsFirst',
+    nullable: true,
+  })
+  async dailyItemizedReportsFirst(
+    @Args() args: FindFirstdailyItemizedReportsArgs,
+  ) {
+    return this.service.findFirst({
+      ...args,
+    } as Prisma.daily_itemized_reportsFindFirstArgs);
   }
 
   @Query(() => [daily_itemized_reports], { name: 'DailyItemizedReportsList' })
-  async dailyItemizedReportsList(@Args() args: FindManydailyItemizedReportsArgs) {
-    return this.service.findMany({ ...args });
+  async dailyItemizedReportsList(
+    @Args() args: FindManydailyItemizedReportsArgs,
+  ) {
+    return this.service.findMany({
+      ...args,
+    } as Prisma.daily_itemized_reportsFindManyArgs);
   }
 
-  @Mutation(() => daily_itemized_reports, { name: 'CreateDailyItemizedReports' })
-  async createDailyItemizedReports(@Args() args: CreateOnedailyItemizedReportsArgs) {
+  @Mutation(() => daily_itemized_reports, {
+    name: 'CreateDailyItemizedReports',
+  })
+  async createDailyItemizedReports(
+    @Args() args: CreateOnedailyItemizedReportsArgs,
+  ) {
     return this.service.create({ ...args });
   }
 
-  @Mutation(() => daily_itemized_reports, { name: 'UpdateDailyItemizedReports' })
-  async updateDailyItemizedReports(@Args() args: UpdateOnedailyItemizedReportsArgs) {
-    return this.service.update({ ...args });
+  @Mutation(() => daily_itemized_reports, {
+    name: 'UpdateDailyItemizedReports',
+  })
+  async updateDailyItemizedReports(
+    @Args() args: UpdateOnedailyItemizedReportsArgs,
+  ) {
+    return this.service.update({
+      ...args,
+    } as Prisma.daily_itemized_reportsUpdateArgs);
   }
 
-  @Mutation(() => daily_itemized_reports, { name: 'UpsertDailyItemizedReports' })
-  async upsertDailyItemizedReports(@Args() args: UpsertOnedailyItemizedReportsArgs) {
-    return this.service.upsert({ ...args });
+  @Mutation(() => daily_itemized_reports, {
+    name: 'UpsertDailyItemizedReports',
+  })
+  async upsertDailyItemizedReports(
+    @Args() args: UpsertOnedailyItemizedReportsArgs,
+  ) {
+    return this.service.upsert({
+      ...args,
+    } as Prisma.daily_itemized_reportsUpsertArgs);
   }
 
-  @Mutation(() => daily_itemized_reports, { name: 'DeleteDailyItemizedReports' })
-  async deleteDailyItemizedReports(@Args() args: DeleteOnedailyItemizedReportsArgs) {
-    return this.service.delete({ ...args });
+  @Mutation(() => daily_itemized_reports, {
+    name: 'DeleteDailyItemizedReports',
+  })
+  async deleteDailyItemizedReports(
+    @Args() args: DeleteOnedailyItemizedReportsArgs,
+  ) {
+    return this.service.delete({
+      ...args,
+    } as Prisma.daily_itemized_reportsDeleteArgs);
   }
 }

--- a/backend/src/database/daily_reports/daily_reports.resolver.ts
+++ b/backend/src/database/daily_reports/daily_reports.resolver.ts
@@ -1,14 +1,15 @@
 import {
-    CreateOnedailyReportsArgs,
-    DeleteOnedailyReportsArgs,
-    FindFirstdailyReportsArgs,
-    FindManydailyReportsArgs,
-    FindUniquedailyReportsArgs,
-    daily_reports,
-    UpdateOnedailyReportsArgs,
+  CreateOnedailyReportsArgs,
+  DeleteOnedailyReportsArgs,
+  FindFirstdailyReportsArgs,
+  FindManydailyReportsArgs,
+  FindUniquedailyReportsArgs,
+  daily_reports,
+  UpdateOnedailyReportsArgs,
 } from '../../@generated/prisma-nestjs-graphql/index';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { DailyReportsService } from './daily_reports.service';
+import { Prisma } from '@prisma/client';
 
 @Resolver()
 export class DailyReportsResolver {
@@ -16,17 +17,23 @@ export class DailyReportsResolver {
 
   @Query(() => daily_reports, { name: 'DailyReports', nullable: true })
   async DailyReports(@Args() args: FindUniquedailyReportsArgs) {
-    return this.service.findUnique({ ...args });
+    return this.service.findUnique({
+      ...args,
+    } as Prisma.daily_reportsFindUniqueArgs);
   }
 
   @Query(() => daily_reports, { name: 'DailyReportsFirst', nullable: true })
   async dailyReportsFirst(@Args() args: FindFirstdailyReportsArgs) {
-    return this.service.findFirst({ ...args });
+    return this.service.findFirst({
+      ...args,
+    } as Prisma.daily_reportsFindFirstArgs);
   }
 
   @Query(() => [daily_reports], { name: 'DailyReportsList' })
   async dailyReportsList(@Args() args: FindManydailyReportsArgs) {
-    return this.service.findMany({ ...args });
+    return this.service.findMany({
+      ...args,
+    } as Prisma.daily_reportsFindManyArgs);
   }
 
   @Mutation(() => daily_reports, { name: 'CreateDailyReports' })
@@ -36,11 +43,11 @@ export class DailyReportsResolver {
 
   @Mutation(() => daily_reports, { name: 'UpdateDailyReports' })
   async updateDailyReports(@Args() args: UpdateOnedailyReportsArgs) {
-    return this.service.update({ ...args });
+    return this.service.update({ ...args } as Prisma.daily_reportsUpdateArgs);
   }
 
   @Mutation(() => daily_reports, { name: 'DeleteDailyReports' })
   async deleteDailyReports(@Args() args: DeleteOnedailyReportsArgs) {
-    return this.service.delete({ ...args });
+    return this.service.delete({ ...args } as Prisma.daily_reportsDeleteArgs);
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,6 +4,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors();
   await app.listen(env.PORT);
 }
 bootstrap();

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -12,7 +12,7 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
   }
 
   async enableShutdownHooks(app: INestApplication) {
-    this.$on('beforeExit', async () => {
+    process.on('beforeExit', async () => {
       await app.close();
     });
   }

--- a/frontend/components/DailyRowComponents.tsx
+++ b/frontend/components/DailyRowComponents.tsx
@@ -39,7 +39,7 @@ const DailyRowComponents = (props: Props) => {
   //開始時刻が変更された場合
   const startTimeChangeHandler = (event:ChangeEvent<HTMLInputElement>) => {
     setStartTime(event.target.value)
-    setOperationTime1(diffTime(event.target.value, endTime, 9))
+    setOperationTime1(diffTime(event.target.value, endTime))
     setOperationTime2("00:00")
   }
 


### PR DESCRIPTION
## 📝変更の目的/背景
2023/8実施のハンズオンで詰まった箇所について、手順を最新化したい。
## 🔨変更内容

**1. 「README.md」の修正**

・「時刻の入力時に動く関数を実装する」のコードをソースに合わせて修正
・「Upsertの実装」のコードをソースに合わせて修正

**2.「DailyRowComponents.tsx」の修正**
→`startTimeChangeHandler`内の`setOperationTime1`の引数に不要な値を削除

**3.「daily_itemized_reports.resolver.ts」の修正**
→upsertについてprismaのv5.2に対応（asでキャストする）

**4. 直前までのstep修正内容を反映**
- 「prisma.service.ts」の修正
- 「daily_itemized_reports.resolver.ts」の修正
- 「daily_reports.resolver.ts」の修正
- 「main.ts」の修正
- 「app.module.ts」の修正